### PR TITLE
Add of PoseTrack18 output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ After the data download, your `JTA-Dataset` directory will contain the following
       ```bash
       python coco_style_convert.py --out_dir_path='coco_annotations'
       ```
+- `posetrack_style_convert.py`: Python script for annotation conversion (from JTA format to PoseTrack18 format).
+    - requires Python >= 3.6 (see [`requirements.txt`](https://github.com/fabbrimatteo/JTA-Dataset/blob/master/requirements.txt) for more details)
+    - use `python posetrack_style_convert.py --help` to read the help message
+    - usage example: 
+      ```bash
+      python posetrack_style_convert.py --out_dir_path='posetrack_annotations --max_frame=200'
+      ```
       
 - `joint.py` and `pose.py`: support classes for the scripts.
 

--- a/pose.py
+++ b/pose.py
@@ -10,99 +10,113 @@ from joint import Joint
 
 
 class Pose(list):
-	"""
+    """
 	a Pose is a list of Joint(s) belonging to the same person.
 	"""
 
-	LIMBS = [
-		(0, 1),  # head_top -> head_center
-		(1, 2),  # head_center -> neck
-		(2, 3),  # neck -> right_clavicle
-		(3, 4),  # right_clavicle -> right_shoulder
-		(4, 5),  # right_shoulder -> right_elbow
-		(5, 6),  # right_elbow -> right_wrist
-		(2, 7),  # neck -> left_clavicle
-		(7, 8),  # left_clavicle -> left_shoulder
-		(8, 9),  # left_shoulder -> left_elbow
-		(9, 10),  # left_elbow -> left_wrist
-		(2, 11),  # neck -> spine0
-		(11, 12),  # spine0 -> spine1
-		(12, 13),  # spine1 -> spine2
-		(13, 14),  # spine2 -> spine3
-		(14, 15),  # spine3 -> spine4
-		(15, 16),  # spine4 -> right_hip
-		(16, 17),  # right_hip -> right_knee
-		(17, 18),  # right_knee -> right_ankle
-		(15, 19),  # spine4 -> left_hip
-		(19, 20),  # left_hip -> left_knee
-		(20, 21)  # left_knee -> left_ankle
-	]
+    LIMBS = [
+        (0, 1),  # head_top -> head_center
+        (1, 2),  # head_center -> neck
+        (2, 3),  # neck -> right_clavicle
+        (3, 4),  # right_clavicle -> right_shoulder
+        (4, 5),  # right_shoulder -> right_elbow
+        (5, 6),  # right_elbow -> right_wrist
+        (2, 7),  # neck -> left_clavicle
+        (7, 8),  # left_clavicle -> left_shoulder
+        (8, 9),  # left_shoulder -> left_elbow
+        (9, 10),  # left_elbow -> left_wrist
+        (2, 11),  # neck -> spine0
+        (11, 12),  # spine0 -> spine1
+        (12, 13),  # spine1 -> spine2
+        (13, 14),  # spine2 -> spine3
+        (14, 15),  # spine3 -> spine4
+        (15, 16),  # spine4 -> right_hip
+        (16, 17),  # right_hip -> right_knee
+        (17, 18),  # right_knee -> right_ankle
+        (15, 19),  # spine4 -> left_hip
+        (19, 20),  # left_hip -> left_knee
+        (20, 21)  # left_knee -> left_ankle
+    ]
 
-	SKELETON = [[l[0] + 1, l[1] + 1] for l in LIMBS]
+    SKELETON = [[l[0] + 1, l[1] + 1] for l in LIMBS]
 
+    def __init__(self, joints, person_id=None):
+        # type: (List[Joint]) -> None
+        super().__init__(joints)
+        self.person_id = int(person_id)
 
-	def __init__(self, joints):
-		# type: (List[Joint]) -> None
-		super().__init__(joints)
-
-
-	@property
-	def invisible(self):
-		# type: () -> bool
-		"""
+    @property
+    def invisible(self):
+        # type: () -> bool
+        """
 		:return: True if all the joints of the pose are occluded, False otherwise
 		"""
-		for j in self:
-			if not j.occ:
-				return False
-		return True
+        for j in self:
+            if not j.occ:
+                return False
+        return True
 
-
-	@property
-	def bbox_2d(self):
-		# type: () -> List[int]
-		"""
+    @property
+    def bbox_2d(self):
+        # type: () -> List[int]
+        """
 		:return: bounding box around the pose in format [x_min, y_min, width, height]
 			- x_min = x of the top left corner of the bounding box
 			- y_min = y of the top left corner of the bounding box
 		"""
-		x_min = int(np.min([j.x2d for j in self]))
-		y_min = int(np.min([j.y2d for j in self]))
-		x_max = int(np.max([j.x2d for j in self]))
-		y_max = int(np.max([j.y2d for j in self]))
-		width = x_max - x_min
-		height = y_max - y_min
-		return [x_min, y_min, width, height]
-	
-	
-	@property
-	def bbox_2d_padded(self, h_inc_perc=0.15, w_inc_perc=0.1):
-		x_min = int(np.min([j.x2d for j in self]))
-		y_min = int(np.min([j.y2d for j in self]))
-		x_max = int(np.max([j.x2d for j in self]))
-		y_max = int(np.max([j.y2d for j in self]))
-		width = x_max - x_min
-		height = y_max - y_min
+        x_min = int(np.min([j.x2d for j in self]))
+        y_min = int(np.min([j.y2d for j in self]))
+        x_max = int(np.max([j.x2d for j in self]))
+        y_max = int(np.max([j.y2d for j in self]))
+        width = x_max - x_min
+        height = y_max - y_min
+        return [x_min, y_min, width, height]
 
-		inc_h = (height * h_inc_perc) / 2
-		inc_w = (width * w_inc_perc) / 2
+    @property
+    def bbox_head_2d(self):
+        # type: () -> List[int]
+        """
+		The bbox_head is computed by tacking a square centered around the head with
+		sides of length equal to two times the distance between the head_top and head_center.
+        WARNING: it may be wrong !
+        :return: bounding box around the head in format [x_min, y_min, width, height]
+            - x_min = x of the top left corner of the head bounding box
+            - y_min = y of the top left corner of the head bounding box
+        """
+        bbox_length = 2 * np.sqrt((self[0].x2d - self[1].x2d) ** 2 + (self[0].y2d - self[1].y2d) ** 2)
+        x_min = int(self[1].x2d - bbox_length / 2)
+        y_min = int(self[1].y2d - bbox_length / 2)
+        width = int(bbox_length)
+        height = int(bbox_length)
+        return [x_min, y_min, width, height]
 
-		x_min = x_min - inc_w
-		x_max = x_max + inc_w
+    @property
+    def bbox_2d_padded(self, h_inc_perc=0.15, w_inc_perc=0.1):
+        x_min = int(np.min([j.x2d for j in self]))
+        y_min = int(np.min([j.y2d for j in self]))
+        x_max = int(np.max([j.x2d for j in self]))
+        y_max = int(np.max([j.y2d for j in self]))
+        width = x_max - x_min
+        height = y_max - y_min
 
-		y_min = y_min - inc_h
-		y_max = y_max + inc_h
+        inc_h = (height * h_inc_perc) / 2
+        inc_w = (width * w_inc_perc) / 2
 
-		width = x_max - x_min
-		height = y_max - y_min
+        x_min = x_min - inc_w
+        x_max = x_max + inc_w
 
-		return [x_min, y_min, width, height]
+        y_min = y_min - inc_h
+        y_max = y_max + inc_h
 
-	
-	@property
-	def coco_annotation(self):
-		# type: () -> Dict
-		"""
+        width = x_max - x_min
+        height = y_max - y_min
+
+        return [x_min, y_min, width, height]
+
+    @property
+    def coco_annotation(self):
+        # type: () -> Dict
+        """
 		:return: COCO annotation dictionary of the pose
 		==========================================================
 		NOTE#1: in COCO, each keypoint is represented by its (x,y)
@@ -117,39 +131,73 @@ class Pose(list):
 		v=2 for each keypoint.
 		==========================================================
 		"""
-		keypoints = []
-		for j in self:
-			keypoints += [j.x2d, j.y2d, 2]
-		annotation = {
-			'keypoints': keypoints,
-			'num_keypoints': len(self),
-			'bbox': self.bbox_2d
-		}
-		return annotation
+        keypoints = []
+        for j in self:
+            keypoints += [j.x2d, j.y2d, 2]
+        annotation = {
+            'keypoints': keypoints,
+            'num_keypoints': len(self),
+            'bbox': self.bbox_2d
+        }
+        return annotation
 
+    @property
+    def posetrack_annotation(self):
+        # type: () -> Dict
+        """
+        :return: PoseTrack annotation dictionary of the pose
+        ==========================================================
+        NOTE#1: in PoseTrack, each keypoint is represented by its (x,y)
+        2D location and a visibility flag `v` defined as:
+            - `v=0` ==> not visible
+            - `v=1` ==> visible
+        ==========================================================
+        NOTE#2: in PoseTrack, keypoints that are not visible are not labeled and
+        set to (x=y=v=0). In JTA every keypoint is labelled, so keypoints with
+        v = 0 are labelled with their true (x,y) location.
+        ==========================================================
+        NOTE#3: in PoseTrack, the bbox_head attribute has been human annotated.
+        The bbox_head is computed by tacking a square centered around the head with
+        sides of length equal to two times the distance between the head_top and
+        head_center.
+        WARNING: it may be wrong !
+        ==========================================================
+        """
+        keypoints = []
+        for j in self:
+            if j.occ:
+                keypoints += [j.x2d, j.y2d, 0]
+            else:
+                keypoints += [j.x2d, j.y2d, 1]
+        annotation = {
+            'bbox_head': self.bbox_head_2d,
+            'keypoints': keypoints,
+            'bbox': self.bbox_2d,
+            'track_id': self.person_id,
+        }
+        return annotation
 
-	def draw(self, image, color):
-		# type: (np.ndarray, List[int]) -> np.ndarray
-		"""
+    def draw(self, image, color):
+        # type: (np.ndarray, List[int]) -> np.ndarray
+        """
 		:param image: image on which to draw the pose
 		:param color: color of the limbs make up the pose
 		:return: image with the pose
 		"""
-		# draw limb(s) segments
-		for (j_id_a, j_id_b) in Pose.LIMBS:
-			joint_a = self[j_id_a]  # type: Joint
-			joint_b = self[j_id_b]  # type: Joint
-			t = 1 if joint_a.cam_distance > 25 else 2
-			if joint_a.is_on_screen and joint_b.is_on_screen:
-				cv2.line(image, joint_a.pos2d, joint_b.pos2d, color=color, thickness=t)
+        # draw limb(s) segments
+        for (j_id_a, j_id_b) in Pose.LIMBS:
+            joint_a = self[j_id_a]  # type: Joint
+            joint_b = self[j_id_b]  # type: Joint
+            t = 1 if joint_a.cam_distance > 25 else 2
+            if joint_a.is_on_screen and joint_b.is_on_screen:
+                cv2.line(image, joint_a.pos2d, joint_b.pos2d, color=color, thickness=t)
 
-		# draw joint(s) circles
-		for joint in self:
-			image = joint.draw(image)
+        # draw joint(s) circles
+        for joint in self:
+            image = joint.draw(image)
 
-		return image
+        return image
 
-
-	def __iter__(self):
-		# type: () -> Iterator[Joint]
-		return super().__iter__()
+    def __iter__(self):
+        # type: () -> Iterator[Joint]
+        return super().__iter__()

--- a/posetrack_style_convert.py
+++ b/posetrack_style_convert.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+# ---------------------
+
+import json
+import sys
+
+import click
+import imageio
+import numpy as np
+from path import Path
+
+from joint import Joint
+from pose import Pose
+
+
+MAX_COLORS = 42
+
+# check python version
+assert sys.version_info >= (3, 6), '[!] This script requires Python >= 3.6'
+
+
+def get_pose(frame_data, person_id):
+    # type: (np.ndarray, int) -> Pose
+    """
+    :param frame_data: data of the current frame
+    :param person_id: person identifier
+    :return: list of joints in the current frame with the required person ID
+    """
+    pose = [Joint(j) for j in frame_data[frame_data[:, 1] == person_id]]
+    pose.sort(key=(lambda j: j.type))
+    return Pose(pose, person_id)
+
+
+H1 = 'path of the output directory'
+H2 = 'Consider only the first n frames.' \
+    + ' Must be a positive integer between 0 and 900.'
+
+
+@click.command()
+@click.option('--out_dir_path', type=click.Path(), prompt='Enter \'out_dir_path\'', help=H1)
+@click.option('--max_frame', type=click.IntRange(min=0, max=900), prompt="Enter the number of frame to process" \
+           + " (integer between 0 and 900)", help=H2)
+def main(out_dir_path, max_frame):
+    # type: (str) -> None
+    """
+    Script for annotation conversion (from JTA format to PoseTrack format)
+    """
+
+    out_dir_path = Path(out_dir_path).abspath()
+    if not out_dir_path.exists():
+        out_dir_path.makedirs()
+
+    for dir in Path('annotations').dirs():
+        basename = dir.basename()
+        out_subdir_path = out_dir_path / basename
+        if not out_subdir_path.exists():
+            out_subdir_path.makedirs()
+        print(f'▸ converting \'{basename}\' set')
+        for anno in dir.files():
+
+            with open(anno, 'r') as json_file:
+                data = json.load(json_file)
+                data = np.array(data)
+
+            print(f'▸ converting annotations of \'{Path(anno).abspath()}\'')
+
+            # getting sequence number from `anno`
+            sequence = None
+            try:
+                sequence = int(Path(anno).basename().split('_')[1].split('.')[0])
+            except:
+                print('[!] error during conversion.')
+                print('\ttry using JSON files with the original nomenclature.')
+
+            posetrack_dict = {
+                'images': [],
+                'annotations': [],
+                'categories': [{
+                    'supercategory': 'person',
+                    'id': 1,
+                    'name': 'person',
+                    'keypoints': Joint.NAMES,
+                    'skeleton': Pose.SKELETON
+                }]
+            }
+
+            for frame_number in range(0, max_frame):
+
+                image_id = sequence * 1000 + (frame_number + 1)
+                posetrack_dict['images'].append({
+                    "has_no_densepose": True,
+                    "is_labeled": True,
+                    "file_name": f"frames/{basename}/seq_{sequence}/{frame_number + 1}.jpg",
+                    "nframes": max_frame,
+                    "frame_id": image_id,
+                    "vid_id": f"{sequence}",
+                    "id": image_id
+                })
+
+                # NOTE: frame #0 does NOT exists: first frame is #1
+                frame_data = data[data[:, 0] == frame_number + 1]  # type: np.ndarray
+
+                for p_id in set(frame_data[:, 1]):
+                    pose = get_pose(frame_data=frame_data, person_id=p_id)
+
+                    # ignore the "invisible" poses
+                    # (invisible pose = pose of which I do not see any joint)
+                    if pose.invisible:
+                        continue
+
+                    annotation = pose.posetrack_annotation
+                    annotation['image_id'] = image_id
+                    annotation['id'] = image_id * 100000 + int(p_id)
+                    annotation['category_id'] = 1
+                    annotation['scores'] = []
+                    posetrack_dict['annotations'].append(annotation)
+
+                print(f'\r▸ progress: {100 * (frame_number / (max_frame-1)):6.2f}%', end='')
+
+            print()
+            out_file_path = out_subdir_path / f'seq_{sequence}.json'
+            with open(out_file_path, 'w') as f:
+                json.dump(posetrack_dict, f)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
In case you want to train or eval using the posetrack18 format (using [poseval](https://github.com/leonid-pishchulin/poseval), [trackeval](https://github.com/JonathonLuiten/TrackEval) by example).

/!\  in PoseTrack, the `bbox_head` attribute has been humanly annotated. Here, the `bbox_head` is computed by tacking a square centered around the head with sides of length equal to two times the distance between the `head_top` and `head_center`. They might thus been erroned.

/!\  JTA contains coordinates that are outside the image dimensions. PoseTrack does not. You may need to clean those data.